### PR TITLE
Small bugfix in the __repr__ method of `network.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+
+# artefacts from installing through setup.py
+fission.egg-info/*
+build/*

--- a/fission/core/network.py
+++ b/fission/core/network.py
@@ -759,8 +759,8 @@ class Network():
     def __repr__(self):
         debug = "Nodes\n"
         for i in self.nodes.values():
-            debug+=f"node {i} : {i.active()} Group: {[j.name for j in i.GROUPS]}\n"
+            debug+=f"node {i} : {i.active} Group: {[j.name for j in i.GROUPS]}\n"
         debug +="\n Jobs\n"
-        for i in self.jobs.values:
-            debug+=f"job {i} : Group: {[g.name for g in g.GROUPS]}"
+        for i in self.jobs.values():
+            debug+=f"job {i} : Group: {[g.name for g in i.GROUPS]}"
         return "Network: {} Nodes | {} Jobs".format(len(self.nodes), len(self.jobs))

--- a/fission/core/network.py
+++ b/fission/core/network.py
@@ -476,7 +476,7 @@ class Network():
     def has_inactive_nodes(self):
         debug = ""
         for n in self.nodes.values():
-            if not n.active():
+            if not n.active:
                 debug+=f"Node {n} is still inactive\n"
         if debug:
             #logger.debug(debug)

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ setuptools.setup(
     packages=["fission"] +
         setuptools.find_packages(include=["fission.*"]),
     install_requires=[
-        'dispy>=4.12',
-        'lxml==4.4.2',
+        'dispy==4.12.3',
+        'lxml>=4.4.2',
         'pycos>=4.8.13',
-        'graphviz==0.13.2',
-        'networkx==2.6.3',
-        'matplotlib==3.5.2',
+        'graphviz>=0.13.2',
+        'networkx>=2.6.3',
+        'matplotlib>=3.5.2',
     ]
 )


### PR DESCRIPTION
In the `__repr__` method of the network, there were a few small bugs that would cause the program to crash if it was called. 

1. `active` is a property of a node, which returns a boolean. This means that if it were to be called as `active()`, an attempt was made to call a boolean, which is impossible.
2. Similarly, `values()` is a method, meaning that just calling `values` will also crash as the return argument is not what was expected.
3. Lastly, in the list comprehension for the jobs, there was an error where `g for g in g.GROUPS` was called, while the iteration variable is `i`. This has been changed to `g for g in i.GROUPS`.

Furthermore, installation using `python==3.10.15` and the `setup.py` script fails because it fails to build the wheel for `lxml==4.4.2`, therefore the dependencies have been allowed to be a higher version, which appears not to cause any problems.

Lastly, a `.gitignore` file has been added to avoid pushing the builds of the editable installs as well as some artefacts created by the installation through `setup.py` (a folder called `fission.egg-info`.
